### PR TITLE
space between user and - let puppet fail to download sdk resource

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -50,7 +50,7 @@ define sdkman::package (
   if $ensure == present and $is_default {
     exec {"sdk default $package_name $version" :
       environment => $sdkman::base_env,
-      command     => "su -c '$sdkman_init && sdk default $package_name $version' -${::sdkman::owner}",
+      command     => "su -c '$sdkman_init && sdk default $package_name $version' - ${::sdkman::owner}",
       user        => 'root',
       path        => '/usr/bin:/usr/sbin:/bin',
       logoutput   => true,


### PR DESCRIPTION
puppet fails with the following error: 

```
Notice: /Stage[main]/Laptop/Sdkman::Package[groovy]/Exec[sdk default groovy 2.4.5]/returns:   -s, --shell SHELL             use SHELL instead of the default in passwd
Error: 'su -c 'source /home/jeroen/.sdkman/bin/sdkman-init.sh && sdk default groovy 2.4.5' -jeroen' returned 2 instead of one of [0]
Error: /Stage[main]/Laptop/Sdkman::Package[groovy]/Exec[sdk default groovy 2.4.5]/returns: change from 'notrun' to ['0'] failed: 'su -c 'source /home/jeroen/.sdkman/bin/sdkman-init.sh && sdk default groovy 2.4.5' -jeroen' returned 2 instead of one of [0]
Notice: Applied catalog in 1.06 seconds
```

this small pull request fixes the error