### PR TITLE
Fix fetch error and Puppet metadata error

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,11 +45,10 @@ class sdkman (
         default => [$home_env, "JAVA_HOME=$java_home"]
     }
 
-    wget::fetch {'https://get.sdkman.io':
-      destination => '/tmp/sdkman-install.sh',
-      verbose     => true,
-      execuser    => $owner,
-      user        => $owner,
+    archive {'/tmp/sdkman-install.sh':
+      ensure => present,
+      source => 'https://get.sdkman.io',
+      user   => $owner,
     } ~>
     exec { 'Install Sdkman' :
       user        => $owner,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,8 +26,6 @@ class sdkman (
     $package_hash = {}
 ) {
 
-    validate_hash($package_hash)
-
     $user_group = $group ? {
       ''      => $owner,
       default => $group

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class sdkman (
         default => [$home_env, "JAVA_HOME=$java_home"]
     }
 
-    wget::fetch {'http://get.sdkman.io':
+    wget::fetch {'https://get.sdkman.io':
       destination => '/tmp/sdkman-install.sh',
       verbose     => true,
       execuser    => $owner,

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,6 @@
 "source": "https://github.com/paulosuzart/sdkman",
 "issues_url": null,
 "dependencies": [{
-  "name": "maestrodev/wget",
-  "version_range": ">= 1.3.1"}]
+  "name": "puppet/archive",
+  "version_range": ">= 7.0.0"}]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -4,6 +4,7 @@
 "description": "Installs Sdkman and any package supported by it",
 "license": "Apache License 2.0",
 "summary": "Paulo Suzart Sdkman module",
+"author": "Paulo Suzart",
 "project_page": "https://github.com/paulosuzart/sdkman",
 "source": "https://github.com/paulosuzart/sdkman",
 "issues_url": null,


### PR DESCRIPTION
This PR address the following errors:
- wget fetch error because http://get.sdkman.io is no longer reachable, solution is to switch to https
- Puppet metadata error because metadata.json doesn't have author property, solution is to add author property and value